### PR TITLE
#2 [feat] add LLMChatView UI

### DIFF
--- a/LLMPractice/App/LLMPracticeApp.swift
+++ b/LLMPractice/App/LLMPracticeApp.swift
@@ -13,6 +13,10 @@ struct LLMPracticeApp: App {
     var sharedModelContainer: ModelContainer = { 
         let schema: Schema = Schema([ // 데이터베이스에 저장될 모델들 정의
             User.self,
+            PlayList.self,
+            Song.self,
+            RequestMessage.self,
+            ResponseMessage.self
         ])
 
         // 데이터를 기기에 저장할지 아닐지 결정

--- a/LLMPractice/Core/Extension/MusicKitManager.swift
+++ b/LLMPractice/Core/Extension/MusicKitManager.swift
@@ -13,6 +13,7 @@ class MusicKitManager {
     static let shared = MusicKitManager()
     private init() {}
 
+    // MARK: - 음악 검색
     func fetchMusic(_ txt: String) async throws -> [Song] {
         let status = await MusicAuthorization.request() // 음악 권한 요청
 
@@ -21,16 +22,15 @@ class MusicKitManager {
                 do {
                     var request = MusicCatalogSearchRequest(term: txt, types: [MusicKit.Song.self])
                     request.limit = 10 // 검색 결과 10개
-                    request.offset = 1 // 검색 결과 1번째 결과부터 가져옴
+                    request.offset = 0 // 검색 결과 0번째 결과부터 가져옴
 
                     let result = try await request.response() // 검색 결과 가져옴
                     
-                    // MusicKit의 Song을 우리 앱의 Song 모델로 변환
+                    // MusicKit의 Song을 앱의 Song 모델로 변환
                     let songs = result.songs.map { musicKitSong in
                         Song.from(musicKitSong: musicKitSong)
                     }
-                    
-                    Logger.shared.info("음악 검색 완료: \(songs.count)개의 결과")
+            
                     return songs
                 } catch {
                     Logger.shared.error("음악 검색 중 오류 발생: \(error.localizedDescription)")

--- a/LLMPractice/Core/Utilities/ErrorMessage.swift
+++ b/LLMPractice/Core/Utilities/ErrorMessage.swift
@@ -1,0 +1,17 @@
+//
+//  ErrorMessage.swift
+//  LLMPractice
+//
+//  Created by 안홍범 on 2025/05/18.
+//
+
+import Foundation
+
+struct ErrorMessage: Identifiable {
+    let id = UUID()
+    let message: String
+
+    init(_ message: String) {
+        self.message = message
+    }
+}

--- a/LLMPractice/Core/Utilities/Logger.swift
+++ b/LLMPractice/Core/Utilities/Logger.swift
@@ -38,10 +38,6 @@ final class Logger {
         case .critical:
             os_log(.fault, log: logger, "%{public}@", logMessage)
         }
-        
-        #if DEBUG
-        print(logMessage)
-        #endif
     }
     
     // 편의 메서드들

--- a/LLMPractice/Feature/Chat/View/LLMChatView.swift
+++ b/LLMPractice/Feature/Chat/View/LLMChatView.swift
@@ -1,0 +1,151 @@
+//
+//  LLMChatView.swift
+//  LLMPractice
+//
+//  Created by 안홍범 on 2025/05/13.
+//
+
+import SwiftUI
+import SwiftData
+
+struct LLMChatView: View {
+    @Environment(\.modelContext) private var modelContext // 
+    @Query(sort: \RequestMessage.createdAt) private var requestMessages: [RequestMessage] // 메시지 목록 쿼리
+    @ObservedObject var viewModel: LLMChatViewModel
+    @State private var messageText = ""
+    
+    var body: some View {
+        VStack {
+            // 채팅 메시지 목록 뷰
+            ChatMessagesView(requestMessages: requestMessages, isLoading: viewModel.isLoading)
+            
+            // 추천된 곡 목록
+            if !viewModel.recommendedSongs.isEmpty {
+                VStack(alignment: .leading) {
+                    Text("추천된 곡")
+                        .font(.headline)
+                        .padding(.horizontal)
+                    
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        LazyHStack(spacing: 12) {
+                            ForEach(viewModel.recommendedSongs) { song in
+                                SongCard(song: song)
+                            }
+                        }
+                        .padding(.horizontal)
+                    }
+                }
+            }
+            
+            // 메시지 입력 영역
+            HStack {
+                TextField("챗봇에게 물어보세요", text: $messageText)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .disabled(viewModel.isLoading)
+                
+                Button(action: { 
+                    Task {
+                        await viewModel.sendMessage(messageText)
+                        messageText = ""
+                    }
+                }) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.title2)
+                }
+                .disabled(messageText.isEmpty || viewModel.isLoading)
+            }
+            .padding()
+        }
+        .navigationTitle("음악 추천 채팅")
+        .navigationBarTitleDisplayMode(.inline)
+        .alert(item: $viewModel.errorMessage) { errorMessage in
+            Alert(title: Text("오류"), message: Text(errorMessage.message), dismissButton: .default(Text("확인")))
+        }
+    }
+}
+
+struct SongCard: View {
+    let song: Song
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            if let albumArt = song.albumArt,
+               let url = URL(string: albumArt) { // 앨범 아트 URL
+                AsyncImage(url: url) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } placeholder: {
+                    Color.gray
+                }
+                .frame(width: 120, height: 120)
+                .cornerRadius(8)
+            }
+            
+            Text(song.title)
+                .font(.subheadline)
+                .lineLimit(1)
+            
+            Text(song.artist)
+                .font(.caption)
+                .foregroundColor(.gray)
+                .lineLimit(1)
+        }
+        .frame(width: 120)
+    }
+}
+
+struct ChatMessagesView: View {
+    let requestMessages: [RequestMessage]
+    let isLoading: Bool
+    
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                ForEach(requestMessages) { request in
+                    if let response = request.response {
+                        VStack(spacing: 8) {
+                            // 사용자 메시지
+                            HStack {
+                                Spacer()
+                                Text(request.content)
+                                    .padding()
+                                    .background(Color.blue)
+                                    .foregroundColor(.white)
+                                    .cornerRadius(16)
+                            }
+                            // 봇 응답
+                            HStack {
+                                Text(response.content)
+                                    .padding()
+                                    .background(Color.gray.opacity(0.2))
+                                    .cornerRadius(16)
+                                Spacer()
+                            }
+                        }
+                        
+                    }
+                }
+                // 로딩 중일 때 표시
+                if isLoading {
+                    HStack {
+                        ProgressView()
+                            .padding(.trailing, 8)
+                        Text("응답 생성 중...")
+                            .foregroundColor(.gray)
+                        Spacer()
+                    }
+                    .padding()
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(16)
+                }
+            }
+            .padding()
+        }
+        .scrollDismissesKeyboard(.immediately)
+    }
+}
+
+// struct SendMessageView: View {
+    
+// }

--- a/LLMPractice/Feature/Chat/ViewModel/LLMChatViewModel.swift
+++ b/LLMPractice/Feature/Chat/ViewModel/LLMChatViewModel.swift
@@ -1,0 +1,102 @@
+//
+//  LLMChatViewModel.swift
+//  LLMPractice
+//
+//  Created by 안홍범 on 2025/05/13.
+//
+
+import Foundation
+import SwiftUI
+import SwiftData
+import MusicKit
+import OSLog
+
+@MainActor
+final class LLMChatViewModel: ObservableObject {
+    @Published var isLoading = false
+    @Published var recommendedSongs: [Song] = []
+    @Published var errorMessage: ErrorMessage? = nil
+    
+    private let modelContext: ModelContext
+    
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+    
+    // MARK: - 메시지 전송
+    func sendMessage(_ text: String) async {
+        Logger.shared.info("새로운 메시지 전송 시작: \(text)")
+        
+        // 사용자 메시지 저장
+        let requestMessage = RequestMessage(content: text)
+        modelContext.insert(requestMessage)
+        Logger.shared.info("RequestMessage 생성됨: \(requestMessage.id.uuidString)")
+        
+        isLoading = true
+        defer { isLoading = false }
+        
+        // TODO: LLM API 호출 구현
+        // 임시 응답
+        let response = "추천 곡: Dynamite - BTS, Butter - BTS, Permission to Dance - BTS"
+        Logger.shared.info("LLM 응답 생성: \(response)")
+        
+        // 응답 메시지 저장 및 연결
+        let responseMessage = ResponseMessage(content: response, request: requestMessage)
+        requestMessage.response = responseMessage
+        modelContext.insert(responseMessage)
+        Logger.shared.info("ResponseMessage 생성됨: \(responseMessage.id.uuidString)")
+        
+        do {
+            try modelContext.save()
+            Logger.shared.info("SwiftData 저장 완료")
+        } catch {
+            Logger.shared.error("SwiftData 저장 실패: \(error.localizedDescription)")
+        }
+        
+        // 추천된 곡들 검색
+        // await : 메인 스레드(화면 UI) 멈추게 하지 않고 비동기적으로 실행
+        await searchRecommendedSongs(from: response)
+
+        // 저장된 메시지 확인
+        Logger.shared.info("저장된 메시지 확인")
+        do {
+            // 혹시 반영이 늦을 수 있으니 잠깐 대기
+            try await Task.sleep(nanoseconds: 200_000_000) // 0.2초
+            let requestMessages = try modelContext.fetch(FetchDescriptor<RequestMessage>())
+            Logger.shared.info("requestMessages count: \(requestMessages.count)")
+            for request in requestMessages {
+                if let response = request.response {
+                    Logger.shared.info("질문: \(request.content), 응답: \(response.content)")
+                } else {
+                    Logger.shared.info("질문: \(request.content), 응답: (없음)")
+                }
+            }
+        } catch {
+            Logger.shared.error("채팅 내역 조회 실패: \(error.localizedDescription)")
+        }
+    }
+    
+    // MARK: - 추천 곡 검색
+    private func searchRecommendedSongs(from text: String) async {
+        Logger.shared.info("곡 검색 시작: \(text)")
+        
+        let songTitles = text.components(separatedBy: ", ")
+            .map { $0.replacingOccurrences(of: "추천 곡: ", with: "") }
+        
+        for title in songTitles {
+            do {
+                Logger.shared.info("곡 검색 중: \(title)")
+                let songs = try await MusicKitManager.shared.fetchMusic(title)
+                if let firstSong = songs.first {
+                    recommendedSongs.append(firstSong)
+                    Logger.shared.info("곡 검색 성공: \(firstSong.title)")
+                }
+            } catch {
+                // errorMessage가 nil일 때만 할당하여 Alert가 여러 번 뜨지 않도록 함
+                if errorMessage == nil {
+                    errorMessage = ErrorMessage("곡 검색 중 에러 발생: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+}

--- a/LLMPractice/Feature/PlayList/View/PlayListView.swift
+++ b/LLMPractice/Feature/PlayList/View/PlayListView.swift
@@ -6,8 +6,10 @@
 //
 
 import SwiftUI
+import SwiftData
 
 struct PlayListView: View {
+    @Environment(\.modelContext) private var modelContext
     @StateObject private var viewModel = PlayListViewModel()
     @State private var showingCreatePlayList = false
     @State private var newPlayListTitle = ""
@@ -149,9 +151,9 @@ struct PlayListView: View {
                 .presentationDetents([.height(200)])
             }
             .sheet(isPresented: $showingChat) {
-                // TODO: LLM Chat 뷰 구현
-                // ChatView()
-                Text("LLM Chat")
+                NavigationStack {
+                    LLMChatView(viewModel: LLMChatViewModel(modelContext: modelContext))
+                }
             }
             .sheet(isPresented: $showingShare) {
                 // TODO: 공유 기능 구현

--- a/LLMPractice/Feature/PlayList/ViewModel/PlayListViewModel.swift
+++ b/LLMPractice/Feature/PlayList/ViewModel/PlayListViewModel.swift
@@ -27,9 +27,9 @@ class PlayListViewModel: ObservableObject {
         Task {
             try? await Task.sleep(nanoseconds: 1_000_000_000) // 1초 대기
             playList = [
-                PlayList(title: "운동할 때 듣기 좋은 노래"),
-                PlayList(title: "잠잘 때 듣기 좋은 노래"),
-                PlayList(title: "드라이브할 때 듣기 좋은 노래")
+                // PlayList(title: "운동할 때 듣기 좋은 노래"),
+                // PlayList(title: "잠잘 때 듣기 좋은 노래"),
+                // PlayList(title: "드라이브할 때 듣기 좋은 노래")
             ]
             isLoading = false
         }

--- a/LLMPractice/Model/Chatting.swift
+++ b/LLMPractice/Model/Chatting.swift
@@ -1,0 +1,36 @@
+//
+//  ChatMessage.swift
+//  LLMPractice
+//
+//  Created by 안홍범 on 2025/05/13.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class ResponseMessage: Identifiable {
+    private(set) var id: UUID = UUID()
+    var content: String
+    var createdAt: Date
+    var request: RequestMessage?
+
+    init(content: String, request: RequestMessage? = nil, createdAt: Date = Date()) {
+        self.content = content
+        self.request = request
+        self.createdAt = createdAt
+    }
+}
+
+@Model
+final class RequestMessage: Identifiable {
+    private(set) var id: UUID = UUID()
+    var content: String
+    var createdAt: Date
+    @Relationship(deleteRule: .cascade) var response: ResponseMessage? // deleteRule: .cascade : 부모 데이터가 삭제되면 자식 데이터도 삭제됨
+
+    init(content: String, createdAt: Date = Date()) {
+        self.content = content
+        self.createdAt = createdAt
+    }
+}

--- a/LLMPractice/Model/Song.swift
+++ b/LLMPractice/Model/Song.swift
@@ -39,7 +39,7 @@ final class Song: Identifiable {
     }
 }
 
-// MusicKit의 Song을 우리 앱의 Song 모델로 변환하는 확장
+// MusicKit의 Song을 해당 앱의 Song 모델로 변환하는 확장
 extension Song {
     static func from(musicKitSong: MusicKit.Song) -> Song {
         return Song(
@@ -47,7 +47,7 @@ extension Song {
             artist: musicKitSong.artistName,
             albumArt: musicKitSong.artwork?.url(width: 300, height: 300)?.absoluteString,
             duration: musicKitSong.duration ?? 0,
-            musicKitID: musicKitSong.id.rawValue
+            musicKitID: musicKitSong.id.rawValue 
         )
     }
 } 


### PR DESCRIPTION
---

## 챗봇 뷰 UI 추가 

- `LLMChatView`를 추가하여 챗봇 인터페이스(메시지 리스트, 추천 곡, 입력 필드 포함)를 구현함. 사용자 상호작용 및 응답 처리는 `LLMChatViewModel`에서 구현하였고 이 뷰 모델에서 추천곡을 불러오는 로직 처리함 -> 현재 응답을 임시 응답으로 처리한 상태

## 데이터 모델 업데이트

- 사용자와 챗봇 메시지를 나타내는 `RequestMessage`, `ResponseMessage` 모델을 추가함

## 음악 검색 기능 개선

- `MusicKitManager`에서 검색결과 인덱스을 조정하고, `MusicKit.Song`을 앱의 어플에서 정의한 `Song` 모델로 변환함

## 로깅 조정

- 로그 출력 과정에서 같은 로그가 2번씩 출력되는 현상 수정(Logger와 print문을 같이 썼던 것을 발견)
